### PR TITLE
Fix Publish URLs for Updater and add pause between retries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,6 +243,7 @@ def buildInstaller() {
         sh(script: 'yarn --frozen-lockfile --force')
     } catch(error) {
         retry(MAX_RETRY) {
+            sleep(900)
             echo "yarn failed - Retrying"
             sh(script: 'yarn --frozen-lockfile --force')        
         }
@@ -314,12 +315,12 @@ def uploadInstaller(String platform) {
         def packageJSON = readJSON file: "package.json"
         String version = "${packageJSON.version}"
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-            sh "ssh genie.cdt-cloud@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/${version}/${platform}"
-            sh "ssh genie.cdt-cloud@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/${version}/${platform}"
-            sh "scp ${distFolder}/*.* genie.cdt-cloud@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/${version}/${platform}"
-            sh "ssh genie.cdt-cloud@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/latest/${platform}"
-            sh "ssh genie.cdt-cloud@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/latest/${platform}"
-            sh "scp ${distFolder}/*.* genie.cdt-cloud@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/latest/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/cdt-cloud/${version}/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/cdt-cloud/${version}/${platform}"
+            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/cdt-cloud/${version}/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/cdt-cloud/latest/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/cdt-cloud/latest/${platform}"
+            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/cdt-cloud/latest/${platform}"
         }
     } else {
         echo "Skipped upload for branch ${env.BRANCH_NAME}"
@@ -331,7 +332,7 @@ def copyInstaller(String platform, String installer, String extension) {
         def packageJSON = readJSON file: "package.json"
         String version = "${packageJSON.version}"
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-            sh "ssh genie.cdt-cloud@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/cdt-cloud/blueprint/latest/${platform}/${installer}-${version}.${extension}"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/cdt-cloud/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/cdt-cloud/latest/${platform}/${installer}-${version}.${extension}"
         }
     } else {
         echo "Skipped copying installer for branch ${env.BRANCH_NAME}"

--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -30,7 +30,7 @@ win:
     - nsis
   publish:
     provider: generic
-    url: "https://download.eclipse.org/theia/latest/windows"
+    url: "https://download.eclipse.org/theia/cdt-cloud/latest/windows"
 mac:
   icon: resources/icons/MacLauncherIcon/512-512-2.icns
   category: public.app-category.developer-tools
@@ -40,7 +40,7 @@ mac:
     - zip
   publish:
     provider: generic
-    url: "https://download.eclipse.org/theia/latest/macos"
+    url: "https://download.eclipse.org/theia/cdt-cloud/latest/macos"
 linux:
   icon: resources/icons/LinuxLauncherIcon/512-512.png
   category: Development
@@ -50,7 +50,7 @@ linux:
     - AppImage
   publish:
     provider: generic
-    url: "https://download.eclipse.org/theia/latest/linux"
+    url: "https://download.eclipse.org/theia/cdt-cloud/latest/linux"
 
 nsis:
   menuCategory: true

--- a/applications/electron/scripts/notarize.sh
+++ b/applications/electron/scripts/notarize.sh
@@ -15,14 +15,14 @@ if [ -d "${INPUT}" ]; then
 fi
 
 # copy file to storage server
-scp -p "${INPUT}" genie.cloud@projects-storage.eclipse.org:./
+scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
 rm -f "${INPUT}"
 
 # name to use on server
 REMOTE_NAME=${INPUT##*/}
 
 # notarize over ssh
-RESPONSE=$(ssh -q genie.cloud@projects-storage.eclipse.org curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" https://cbi.eclipse.org/macos/xcrun/notarize)
+RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" https://cbi.eclipse.org/macos/xcrun/notarize)
 
 # fund uuid and status
 [[ $RESPONSE =~ $UUID_REGEX ]]
@@ -34,7 +34,7 @@ STATUS=${BASH_REMATCH[1]}
 echo "  Progress: $RESPONSE"
 while [[ $STATUS == 'IN_PROGRESS' ]]; do
     sleep 120
-    RESPONSE=$(ssh -q genie.cloud@projects-storage.eclipse.org curl -s https://cbi.eclipse.org/macos/xcrun/${UUID}/status)
+    RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -s https://cbi.eclipse.org/macos/xcrun/${UUID}/status)
     [[ $RESPONSE =~ $STATUS_REGEX ]]
     STATUS=${BASH_REMATCH[1]}
     echo "  Progress: $RESPONSE"
@@ -46,13 +46,13 @@ if [[ $STATUS != 'COMPLETE' ]]; then
 fi
 
 # download stapled result
-ssh -q genie.cloud@projects-storage.eclipse.org curl -o "\"stapled-${REMOTE_NAME}\"" https://cbi.eclipse.org/macos/xcrun/${UUID}/download
+ssh -q genie.theia@projects-storage.eclipse.org curl -o "\"stapled-${REMOTE_NAME}\"" https://cbi.eclipse.org/macos/xcrun/${UUID}/download
 
 # copy stapled file back from server
-scp -T -p genie.cloud@projects-storage.eclipse.org:"\"./stapled-${REMOTE_NAME}\"" "${INPUT}"
+scp -T -p genie.theia@projects-storage.eclipse.org:"\"./stapled-${REMOTE_NAME}\"" "${INPUT}"
 
 # ensure storage server is clean
-ssh -q genie.cloud@projects-storage.eclipse.org rm -f "\"${REMOTE_NAME}\"" "\"stapled-${REMOTE_NAME}\"" entitlements.plist
+ssh -q genie.theia@projects-storage.eclipse.org rm -f "\"${REMOTE_NAME}\"" "\"stapled-${REMOTE_NAME}\"" entitlements.plist
 
 # if unzip needed
 if [ "$NEEDS_UNZIP" = true ]; then

--- a/applications/electron/scripts/sign.sh
+++ b/applications/electron/scripts/sign.sh
@@ -13,24 +13,24 @@ if [ -d "${INPUT}" ]; then
 fi
 
 # copy file to storage server
-scp -p "${INPUT}" genie.cloud@projects-storage.eclipse.org:./
+scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
 rm -f "${INPUT}"
 
 # copy entitlements to storage server
-scp -p "${ENTITLEMENTS}" genie.cloud@projects-storage.eclipse.org:./entitlements.plist
+scp -p "${ENTITLEMENTS}" genie.theia@projects-storage.eclipse.org:./entitlements.plist
 
 # name to use on server
 REMOTE_NAME=${INPUT##*/}
 
 # sign over ssh
 # https://wiki.eclipse.org/IT_Infrastructure_Doc#Web_service
-ssh -q genie.cloud@projects-storage.eclipse.org curl -f -o "\"signed-${REMOTE_NAME}\"" -F file=@"\"${REMOTE_NAME}\"" -F entitlements=@entitlements.plist https://cbi.eclipse.org/macos/codesign/sign
+ssh -q genie.theia@projects-storage.eclipse.org curl -f -o "\"signed-${REMOTE_NAME}\"" -F file=@"\"${REMOTE_NAME}\"" -F entitlements=@entitlements.plist https://cbi.eclipse.org/macos/codesign/sign
 
 # copy signed file back from server
-scp -T -p genie.cloud@projects-storage.eclipse.org:"\"./signed-${REMOTE_NAME}\"" "${INPUT}"
+scp -T -p genie.theia@projects-storage.eclipse.org:"\"./signed-${REMOTE_NAME}\"" "${INPUT}"
 
 # ensure storage server is clean
-ssh -q genie.cloud@projects-storage.eclipse.org rm -f "\"${REMOTE_NAME}\"" "\"signed-${REMOTE_NAME}\"" entitlements.plist
+ssh -q genie.theia@projects-storage.eclipse.org rm -f "\"${REMOTE_NAME}\"" "\"signed-${REMOTE_NAME}\"" entitlements.plist
 
 # if unzip needed
 if [ "$NEEDS_UNZIP" = true ]; then

--- a/applications/electron/tsconfig.json
+++ b/applications/electron/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../configs/base.tsconfig",
     "include": [],
     "compilerOptions": {
-      "composite": true
+      "composite": true,
+      "esModuleInterop": true,
     },
     "references": [
       {


### PR DESCRIPTION
#### What it does
* adjusts the URL where the updater will be looking for newer version
* adds a pause between retries. This may help with the github rate-limits we are hitting when the electron binaries are downloaded from github

Contributed on behalf of STMicroelectronics
