### PR TITLE
Correct docker setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ yarn electron test
 1. Install the [Remote Dev extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) in VS Code
 2. Open this repository in VS Code
 3. In the notification that should appear: confirm to open this folder in the remote container instead
-4. Once VS Code is opened in the container, run `yarn browser start` in the container's terminal to start the CDT.cloud blueprint backend.
-5. Once, CDT.cloud blueprint is up, it should be running on 127.0.0.1:3000 and can be accessed from the host.
+4. Once VS Code is opened in the container and the `Configuring Dev Container` task is finished, run `yarn browser start` in the container's terminal to start the CDT.cloud blueprint backend.
+5. Once CDT.cloud blueprint is up, it should be running on 127.0.0.1:3000 and can be accessed from the host.
 
 Now you can make changes to the source code and rebuild with `yarn` or run `yarn watch` before the changes. After a browser refresh, your changes should get effective.
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ yarn electron test
 1. Install the [Remote Dev extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) in VS Code
 2. Open this repository in VS Code
 3. In the notification that should appear: confirm to open this folder in the remote container instead
-4. CDT.cloud should be running on 127.0.0.1:3000 (VS Code should notify you on that)
+4. Once VS Code is opened in the container, run `yarn browser start` in the container's terminal to start the CDT.cloud blueprint backend.
+5. Once, CDT.cloud blueprint is up, it should be running on 127.0.0.1:3000 and can be accessed from the host.
 
-This executes the Browser application within a Docker container.
+Now you can make changes to the source code and rebuild with `yarn` or run `yarn watch` before the changes. After a browser refresh, your changes should get effective.
 
 ### Troubleshooting
 


### PR DESCRIPTION
#### What it does
Fixes the documentation on running CDT.cloud blueprint in the devcontainer setup. In fact, the CDT.cloud blueprint is not started automatically after container start. It has to be started manually within the container. Only then the port comes up and is forwarded, which should then also open a browser in the host system.

Contributed on behalf of STMicroelectronics.

#### How to test
Please read the new documentation and test if it works according to the description.
