### PR TITLE
Stop at main when starting a debug session

### DIFF
--- a/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/launch.json
+++ b/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/launch.json
@@ -8,6 +8,7 @@
       "request": "launch",
       "name": "Debug Example C++",
       "program": "${workspaceFolder}/Example",
+      "initCommands": ["tbreak main"],
       "preLaunchTask": "Binary build"
     }
   ]


### PR DESCRIPTION
#### What it does

Adds a temporary breakpoint at `main` in the CMake example project.

This allows the demo run of the example to work a bit more smoothly as starting the debug session won't immediately terminate due to no breakpoints.

#### How to test

Start CDT.cloud, create the CMake example project and debug it. There should be a new line in `.theia/launch.json` that reasds:

```json
      "initCommands": ["tbreak main"],
```
