### PR TITLE
Remove duplicate support entry from welcome page

### DIFF
--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -84,11 +84,6 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
             </div>
             <div className='flex-grid'>
                 <div className='col'>
-                    {renderSupport(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
                     {renderTickets(this.windowService)}
                 </div>
             </div>


### PR DESCRIPTION
fixed #40

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

## How to test

There is only one entry "Professional Support" on the welcome page
