### PR TITLE
Change website URL to eclipse.org/cdt-cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CDT.cloud Blueprint is a template for building custom web-based C/C++ tools. It 
 
 </div>
 
-[Visit the CDT.cloud website for more information](https://cdt-cloud.io/).
+[Visit the CDT.cloud website for more information](https://www.eclipse.org/cdt-cloud/).
 
 ## License
 

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -7,7 +7,7 @@
       "name": "CDT.cloud",
       "email": "cdt-cloud-dev@eclipse.org"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "bugs": {
       "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },

--- a/applications/docker/package.json
+++ b/applications/docker/package.json
@@ -7,7 +7,7 @@
     "name": "CDT.cloud",
     "email": "cdt-cloud-dev@eclipse.org"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -10,7 +10,7 @@
     "name": "CDT.cloud",
     "email": "cdt-cloud-dev@eclipse.org"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "CDT.cloud"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },

--- a/theia-extensions/blueprint-example-generator/package.json
+++ b/theia-extensions/blueprint-example-generator/package.json
@@ -33,7 +33,7 @@
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "files": [
     "resources",
     "lib",

--- a/theia-extensions/theia-blueprint-product/package.json
+++ b/theia-extensions/theia-blueprint-product/package.json
@@ -35,7 +35,7 @@
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "files": [
     "lib",
     "src"

--- a/theia-extensions/theia-blueprint-product/src/browser/branding-util.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/branding-util.tsx
@@ -102,7 +102,7 @@ export function renderSupport(windowService: WindowService): React.ReactNode {
         <div >
             Professional support, implementation services, consulting and training for building tools like this instance of CDT.cloud Blueprint and for
             building other tools based on Eclipse Theia is available by selected companies as listed on
-            the <ExternalBrowserLink text="CDT.cloud support page" url="https://cdt-cloud.io/support/" windowService={windowService} ></ExternalBrowserLink>.
+            the <ExternalBrowserLink text="CDT.cloud support page" url="https://www.eclipse.org/cdt-cloud/support/" windowService={windowService} ></ExternalBrowserLink>.
         </div>
     </div>;
 }
@@ -115,11 +115,11 @@ export function renderTickets(windowService: WindowService): React.ReactNode {
         <div >
             CDT.cloud Blueprint is part of the CDT.cloud project, which hosts components and best practices for building
             customizable web-based C/C++ tools. For more information on CDT.cloud visit us
-            on <ExternalBrowserLink text="our webpage" url="https://cdt-cloud.io"
+            on <ExternalBrowserLink text="our webpage" url="https://www.eclipse.org/cdt-cloud"
                 windowService={windowService} ></ExternalBrowserLink> or
             on <ExternalBrowserLink text="Github" url="https://github.com/eclipse-cdt-cloud/cdt-cloud"
                 windowService={windowService} ></ExternalBrowserLink> and <ExternalBrowserLink text="get in touch"
-                    url="https://cdt-cloud.io/contact" windowService={windowService} ></ExternalBrowserLink> to
+                    url="https://www.eclipse.org/cdt-cloud/contact" windowService={windowService} ></ExternalBrowserLink> to
             discuss ideas, request features, report bugs, or to get support for building your custom C/C++ tool.
         </div>
     </div>;

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-contribution.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-contribution.tsx
@@ -44,7 +44,7 @@ export class TheiaBlueprintContribution implements CommandContribution, MenuCont
     protected readonly windowService: WindowService;
 
     static REPORT_ISSUE_URL = 'https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues/new/choose';
-    static DOCUMENTATION_URL = 'https://cdt-cloud.io/';
+    static DOCUMENTATION_URL = 'https://www.eclipse.org/cdt-cloud/documentation';
 
     registerCommands(commandRegistry: CommandRegistry): void {
         commandRegistry.registerCommand(BlueprintCommands.REPORT_ISSUE, {

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -216,8 +216,8 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
                 <a
                     role={'button'}
                     tabIndex={0}
-                    onClick={() => this.doOpenExternalLink('https://cdt-cloud.io')}
-                    onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, 'https://cdt-cloud.io')}>
+                    onClick={() => this.doOpenExternalLink('https://www.eclipse.org/cdt-cloud/documentation')}
+                    onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, 'https://www.eclipse.org/cdt-cloud/documentation')}>
                     {nls.localizeByDefault('CDT.cloud Documentation')}
                 </a>
             </div>

--- a/theia-extensions/theia-blueprint-updater/package.json
+++ b/theia-extensions/theia-blueprint-updater/package.json
@@ -34,7 +34,7 @@
   "bugs": {
     "url": "https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues"
   },
-  "homepage": "https://cdt-cloud.io/",
+  "homepage": "https://www.eclipse.org/cdt-cloud/",
   "files": [
     "lib",
     "src"


### PR DESCRIPTION
#### What it does
Changes all URLs in `package.json` as well as the links in the welcome page from `cdt-cloud.io` to `eclipse.org/cdt-cloud`.

Contributed on behalf of STMicroelectronics.

#### How to test
* Check `package.json` changes
* Try links in the welcome page