### PR TITLE
Add task to run binary of CMake example

### DIFF
--- a/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/tasks.json
+++ b/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/tasks.json
@@ -17,7 +17,7 @@
       }
     },
     {
-        "label": "Run example",
+        "label": "Launch Example C++",
         "type": "shell",
         "command": "${workspaceFolder}/Example",
         "dependsOn": [ "Binary build" ],

--- a/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/tasks.json
+++ b/theia-extensions/blueprint-example-generator/resources/cmake-example/.theia/tasks.json
@@ -15,6 +15,21 @@
       "runOptions": {
         "runOn": "folderOpen"
       }
+    },
+    {
+        "label": "Run example",
+        "type": "shell",
+        "command": "${workspaceFolder}/Example",
+        "dependsOn": [ "Binary build" ],
+        "presentation": {
+            "echo": true,
+            "reveal": "always",
+            "focus": true,
+            "panel": "shared",
+            "showReuseMessage": false,
+            "clear": true
+        },
+        "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
Fixes #44
Contributed on behalf of STMicroelectronics.

#### What it does
Adds a task that runs the binary (without debugging) to the CMake example.

https://user-images.githubusercontent.com/588090/212020429-04550a69-6226-4907-ad01-2b442666a364.mp4


#### How to test
* Open Blueprint with an empty workspace
* Create the CMake example (e.g. via welcome page link "CMake Example" in example section)
* Run task "Run example"
