### PR TITLE
Rename CDT.cloud Blueprint to CDT Cloud Blueprint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /**
- * This Jenkinsfile builds CDT.cloud Blueprint across the major OS platforms
+ * This Jenkinsfile builds CDT Cloud Blueprint across the major OS platforms
  */
 import groovy.json.JsonSlurper
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,12 +1,12 @@
-# Notices for CDT.cloud Blueprint
+# Notices for CDT Cloud Blueprint
 
-This content is produced and maintained by the CDT.cloud project.
+This content is produced and maintained by the CDT Cloud project.
 
-* Project home: https://projects.eclipse.org/projects/ecd.cdt.cloud
+* Project home: https://projects.eclipse.org/projects/ecd.CDT Cloud
 
 ## Trademarks
 
-CDT.cloud is a trademark of the Eclipse Foundation.
+CDT Cloud is a trademark of the Eclipse Foundation.
 
 ## Copyright
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 This content is produced and maintained by the CDT Cloud project.
 
-* Project home: https://projects.eclipse.org/projects/ecd.CDT Cloud
+* Project home: https://projects.eclipse.org/projects/ecd.cdt.cloud
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <br/>
 <div id="cdt-cloud-logo" align="center">
     <br />
-    <img src="theia-extensions/theia-blueprint-product/src/browser/icons/CDTCloudBlueprintLogo.png" alt="CDT.cloud Blueprint Logo"/>
-    <h3>CDT.cloud Blueprint</h3>
+    <img src="theia-extensions/theia-blueprint-product/src/browser/icons/CDTCloudBlueprintLogo.png" alt="CDT Cloud Blueprint Logo"/>
+    <h3>CDT Cloud Blueprint</h3>
 </div>
 
 <div id="badges" align="center">
 
-CDT.cloud Blueprint is a template for building custom web-based C/C++ tools. It is made up of existing open source components and can be easily downloaded and installed on all major operating system platforms.
+CDT Cloud Blueprint is a template for building custom web-based C/C++ tools. It is made up of existing open source components and can be easily downloaded and installed on all major operating system platforms.
 
 </div>
 
-[Visit the CDT.cloud website for more information](https://www.eclipse.org/cdt-cloud/).
+[Visit the CDT Cloud website for more information](https://www.eclipse.org/cdt-cloud/).
 
 ## License
 
@@ -20,24 +20,24 @@ CDT.cloud Blueprint is a template for building custom web-based C/C++ tools. It 
 
 ## What is this?
 
-CDT.cloud Blueprint is a template for building custom web-based C/C++ tools. It is made up of existing open source components and can be easily downloaded and installed on all major operating system platforms.
+CDT Cloud Blueprint is a template for building custom web-based C/C++ tools. It is made up of existing open source components and can be easily downloaded and installed on all major operating system platforms.
 
 ## What is it not?
 
-CDT.cloud Blueprint is ***not*** **a production-ready product**. Therefore, it is also not meant to be a replacement for Visual Studio Code or any other IDE.
+CDT Cloud Blueprint is ***not*** **a production-ready product**. Therefore, it is also not meant to be a replacement for Visual Studio Code or any other IDE.
 
 ## Current state
 
-CDT.cloud Blueprint is in an early alpha state and undergoing active development.
+CDT Cloud Blueprint is in an early alpha state and undergoing active development.
 See [this milestone for release 1.0](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/milestone/1).
 
 ## Development
 
-CDT.cloud Blueprint is based on [Eclipse Theia Blueprint](https://github.com/eclipse-theia/theia-blueprint).
+CDT Cloud Blueprint is based on [Eclipse Theia Blueprint](https://github.com/eclipse-theia/theia-blueprint).
 
 ### Requirements
 
-Please check Theia's [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites), and keep node versions aligned between CDT.cloud Blueprint and that of the referenced Theia version.
+Please check Theia's [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites), and keep node versions aligned between CDT Cloud Blueprint and that of the referenced Theia version.
 
 ### Documentation
 
@@ -48,7 +48,7 @@ Documentation on how to package Theia as a Desktop Product may be found [here](h
 - Root level configures mono-repo build with lerna
 - `applications` groups the different app targets
   - `electron` contains app to package, packaging configuration, and E2E tests for the Electron target.
-- `theia-extensions` groups the various custom theia extensions for CDT.cloud Blueprint
+- `theia-extensions` groups the various custom theia extensions for CDT Cloud Blueprint
   - `theia-blueprint-product` contains a Theia extension contributing the product branding (about dialogue and welcome page).
   - `theia-blueprint-updater` contains a Theia extension contributing the update mechanism and corresponding UI elements (based on the Electron updater).
 
@@ -96,8 +96,8 @@ yarn electron test
 1. Install the [Remote Dev extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) in VS Code
 2. Open this repository in VS Code
 3. In the notification that should appear: confirm to open this folder in the remote container instead
-4. Once VS Code is opened in the container and the `Configuring Dev Container` task is finished, run `yarn browser start` in the container's terminal to start the CDT.cloud blueprint backend.
-5. Once CDT.cloud blueprint is up, it should be running on 127.0.0.1:3000 and can be accessed from the host.
+4. Once VS Code is opened in the container and the `Configuring Dev Container` task is finished, run `yarn browser start` in the container's terminal to start the CDT Cloud blueprint backend.
+5. Once CDT Cloud blueprint is up, it should be running on 127.0.0.1:3000 and can be accessed from the host.
 
 Now you can make changes to the source code and rebuild with `yarn` or run `yarn watch` before the changes. After a browser refresh, your changes should get effective.
 
@@ -121,5 +121,5 @@ docker run -it -p 0.0.0.0:3000:3000 -p 0.0.0.0:8080:8080 cdt-cloud-blueprint:lat
 
 ### Reporting Feature Requests and Bugs
 
-The features in CDT.cloud Blueprint are based on Theia and the included extensions/plugins. For bugs in Theia please consider opening an issue in the [Theia project on Github](https://github.com/eclipse-theia/theia/issues/new/choose).
-CDT.cloud Blueprint only packages existing functionality into a product and installers for the product. If you believe there is a mistake in packaging, something needs to be added to the packaging or the installers do not work properly, please [open an issue on Github](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues/new/choose) to let us know.
+The features in CDT Cloud Blueprint are based on Theia and the included extensions/plugins. For bugs in Theia please consider opening an issue in the [Theia project on Github](https://github.com/eclipse-theia/theia/issues/new/choose).
+CDT Cloud Blueprint only packages existing functionality into a product and installers for the product. If you believe there is a mistake in packaging, something needs to be added to the packaging or the installers do not work properly, please [open an issue on Github](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/issues/new/choose) to let us know.

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "name": "cdt-cloud-blueprint-browser",
-  "description": "CDT.cloud Blueprint is a template for building custom web-based C/C++ tools",
+  "description": "CDT Cloud Blueprint is a template for building custom web-based C/C++ tools",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "author": {
-      "name": "CDT.cloud",
+      "name": "CDT Cloud",
       "email": "cdt-cloud-dev@eclipse.org"
   },
   "homepage": "https://www.eclipse.org/cdt-cloud/",

--- a/applications/docker/package.json
+++ b/applications/docker/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "name": "cdt-cloud-blueprint-docker",
-  "description": "CDT.cloud Blueprint is a template for building custom web-based C/C++ tools",
+  "description": "CDT Cloud Blueprint is a template for building custom web-based C/C++ tools",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "author": {
-    "name": "CDT.cloud",
+    "name": "CDT Cloud",
     "email": "cdt-cloud-dev@eclipse.org"
   },
   "homepage": "https://www.eclipse.org/cdt-cloud/",

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "cdt-cloud-blueprint",
-  "description": "CDT.cloud Blueprint is a template for building custom web-based C/C++ tools",
-  "productName": "CDT.cloud Blueprint",
+  "description": "CDT Cloud Blueprint is a template for building custom web-based C/C++ tools",
+  "productName": "CDT Cloud Blueprint",
   "version": "1.34.4",
   "main": "scripts/theia-electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "author": {
-    "name": "CDT.cloud",
+    "name": "CDT Cloud",
     "email": "cdt-cloud-dev@eclipse.org"
   },
   "homepage": "https://www.eclipse.org/cdt-cloud/",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.34.4",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "author": {
-    "name": "CDT.cloud"
+    "name": "CDT Cloud"
   },
   "homepage": "https://www.eclipse.org/cdt-cloud/",
   "bugs": {

--- a/theia-extensions/blueprint-example-generator/package.json
+++ b/theia-extensions/blueprint-example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-cdt-cloud/blueprint-example-generator",
   "version": "1.34.4",
-  "description": "Extension for generating examples in CDT Cloud blueprint",
+  "description": "Extension for generating examples in CDT Cloud Blueprint",
   "dependencies": {
     "@theia/core": "1.34.4",
     "@theia/workspace": "1.34.4",

--- a/theia-extensions/blueprint-example-generator/package.json
+++ b/theia-extensions/blueprint-example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-cdt-cloud/blueprint-example-generator",
   "version": "1.34.4",
-  "description": "Extension for generating examples in CDT.cloud blueprint",
+  "description": "Extension for generating examples in CDT Cloud blueprint",
   "dependencies": {
     "@theia/core": "1.34.4",
     "@theia/workspace": "1.34.4",

--- a/theia-extensions/blueprint-example-generator/resources/clangd-contexts/.clangd-contexts
+++ b/theia-extensions/blueprint-example-generator/resources/clangd-contexts/.clangd-contexts
@@ -1,5 +1,5 @@
 {
-    "workspaceName": "CDT.cloud Clangd Contexts Example",
+    "workspaceName": "CDT Cloud Clangd Contexts Example",
     "projects": [
         {
             "path": "app",

--- a/theia-extensions/blueprint-example-generator/resources/clangd-contexts/CLANGD_CONTEXTS_README.md
+++ b/theia-extensions/blueprint-example-generator/resources/clangd-contexts/CLANGD_CONTEXTS_README.md
@@ -5,7 +5,7 @@ This is a simple multi-project workspace that has two different _clangd contexts
 ## How to Build the Workspace
 
 Make sure that you have `gcc` from the GNU toolchain and `cmake` on the `PATH`.
-Then open a terminal in CDT.cloud Blueprint and build the workspace using
+Then open a terminal in CDT Cloud Blueprint and build the workspace using
 
 ```console
 ./build.sh

--- a/theia-extensions/blueprint-example-generator/resources/example-traces/EXAMPLE_TRACES_README.md
+++ b/theia-extensions/blueprint-example-generator/resources/example-traces/EXAMPLE_TRACES_README.md
@@ -1,6 +1,6 @@
 # Workspace with example traces
 
-This workspace contains two example traces licensed under [`Creative Commons Attribution 4.0 International Public License`](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/LICENSE) taken from [here](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/labs/TraceCompassTutorialTraces.tgz). They can be opened using the [CDT Cloud theia trace-extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension).
+This workspace contains two example traces licensed under [`Creative Commons Attribution 4.0 International Public License`](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/LICENSE) taken from [here](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/labs/TraceCompassTutorialTraces.tgz). They can be opened using the [CDT Cloud Theia trace-extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension).
 
 ## Open a trace with the trace view
 

--- a/theia-extensions/blueprint-example-generator/resources/example-traces/EXAMPLE_TRACES_README.md
+++ b/theia-extensions/blueprint-example-generator/resources/example-traces/EXAMPLE_TRACES_README.md
@@ -1,6 +1,6 @@
 # Workspace with example traces
 
-This workspace contains two example traces licensed under [`Creative Commons Attribution 4.0 International Public License`](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/LICENSE) taken from [here](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/labs/TraceCompassTutorialTraces.tgz). They can be opened using the [CDT.cloud theia trace-extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension).
+This workspace contains two example traces licensed under [`Creative Commons Attribution 4.0 International Public License`](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/LICENSE) taken from [here](https://github.com/dorsal-lab/Tracevizlab/blob/3e284690d92435b092204fb14f3d1ec932eea9fb/labs/TraceCompassTutorialTraces.tgz). They can be opened using the [CDT Cloud theia trace-extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension).
 
 ## Open a trace with the trace view
 

--- a/theia-extensions/blueprint-example-generator/src/browser/example-generator-contribution.ts
+++ b/theia-extensions/blueprint-example-generator/src/browser/example-generator-contribution.ts
@@ -25,7 +25,7 @@ import { ExampleGeneratorService, Examples } from '../common/protocol';
 
 export const GenerateExampleCommand: Command = {
     id: 'eclipse-cdt-cloud.example-generator.generate-example',
-    label: 'Generate CDT.cloud Blueprint Example'
+    label: 'Generate CDT Cloud Blueprint Example'
 };
 
 @injectable()

--- a/theia-extensions/blueprint-example-generator/src/common/protocol.ts
+++ b/theia-extensions/blueprint-example-generator/src/common/protocol.ts
@@ -24,7 +24,7 @@ export enum Examples {
 }
 
 /**
- * Service for generating CDT Cloud blueprint examples.
+ * Service for generating CDT Cloud Blueprint examples.
  */
 export interface ExampleGeneratorService {
     /**

--- a/theia-extensions/blueprint-example-generator/src/common/protocol.ts
+++ b/theia-extensions/blueprint-example-generator/src/common/protocol.ts
@@ -24,7 +24,7 @@ export enum Examples {
 }
 
 /**
- * Service for generating CDT.cloud blueprint examples.
+ * Service for generating CDT Cloud blueprint examples.
  */
 export interface ExampleGeneratorService {
     /**

--- a/theia-extensions/theia-blueprint-product/package.json
+++ b/theia-extensions/theia-blueprint-product/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "cdt-cloud-blueprint-product",
   "version": "1.34.4",
-  "description": "CDT.cloud Blueprint Product Branding",
+  "description": "CDT Cloud Blueprint Product Branding",
   "dependencies": {
     "@theia/core": "1.34.4",
     "@theia/getting-started": "1.34.4",

--- a/theia-extensions/theia-blueprint-product/src/browser/branding-util.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/branding-util.tsx
@@ -48,10 +48,10 @@ function openExternalLink(url: string, windowService: WindowService): void {
 export function renderWhatIs(windowService: WindowService, commandService: CommandService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            Welcome to CDT.cloud Blueprint
+            Welcome to CDT Cloud Blueprint
         </h3>
         <div >
-            CDT.cloud Blueprint is a <span className='gs-text-bold'>template</span> tool for building custom, web-based C/C++ tools.
+            CDT Cloud Blueprint is a <span className='gs-text-bold'>template</span> tool for building custom, web-based C/C++ tools.
             Purely based on extensible open source components, it offers a modern and feature-rich C/C++ development experience,
             including language editing and debugging support, memory debugging and a tracing view.
             It is meant to serve as a starting point for the implementation of your own domain-specific custom C/C++ tool.
@@ -84,12 +84,12 @@ function generateExample(commandService: CommandService, exampleId?: Examples): 
 export function renderWhatIsNot(): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            What CDT.cloud Blueprint isn't
+            What CDT Cloud Blueprint isn't
         </h3>
         <div >
-            CDT.cloud Blueprint is <span className='gs-text-bold'>not meant to be used as a production-ready product</span>.
+            CDT Cloud Blueprint is <span className='gs-text-bold'>not meant to be used as a production-ready product</span>.
             However, feel free to use it a template for building your own custom C/C++ tool based on this blueprint, as well
-            as for testing the integrated CDT.cloud components.
+            as for testing the integrated CDT Cloud components.
         </div>
     </div>;
 }
@@ -100,9 +100,9 @@ export function renderSupport(windowService: WindowService): React.ReactNode {
             Professional Support
         </h3>
         <div >
-            Professional support, implementation services, consulting and training for building tools like this instance of CDT.cloud Blueprint and for
+            Professional support, implementation services, consulting and training for building tools like this instance of CDT Cloud Blueprint and for
             building other tools based on Eclipse Theia is available by selected companies as listed on
-            the <ExternalBrowserLink text="CDT.cloud support page" url="https://www.eclipse.org/cdt-cloud/support/" windowService={windowService} ></ExternalBrowserLink>.
+            the <ExternalBrowserLink text="CDT Cloud support page" url="https://www.eclipse.org/cdt-cloud/support/" windowService={windowService} ></ExternalBrowserLink>.
         </div>
     </div>;
 }
@@ -110,11 +110,11 @@ export function renderSupport(windowService: WindowService): React.ReactNode {
 export function renderTickets(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            Get involved with CDT.cloud
+            Get involved with CDT Cloud
         </h3>
         <div >
-            CDT.cloud Blueprint is part of the CDT.cloud project, which hosts components and best practices for building
-            customizable web-based C/C++ tools. For more information on CDT.cloud visit us
+            CDT Cloud Blueprint is part of the CDT Cloud project, which hosts components and best practices for building
+            customizable web-based C/C++ tools. For more information on CDT Cloud visit us
             on <ExternalBrowserLink text="our webpage" url="https://www.eclipse.org/cdt-cloud"
                 windowService={windowService} ></ExternalBrowserLink> or
             on <ExternalBrowserLink text="Github" url="https://github.com/eclipse-cdt-cloud/cdt-cloud"
@@ -128,15 +128,15 @@ export function renderTickets(windowService: WindowService): React.ReactNode {
 export function renderSourceCode(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            Source Code and CDT.cloud components
+            Source Code and CDT Cloud components
         </h3>
         <div >
-            The source code of CDT.cloud Blueprint is available
+            The source code of CDT Cloud Blueprint is available
             on <ExternalBrowserLink text="Github" url="https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint"
                 windowService={windowService} ></ExternalBrowserLink>.
         </div>
         <div >
-            CDT.cloud Blueprint bundles the following CDT.cloud open-source components:
+            CDT Cloud Blueprint bundles the following CDT Cloud open-source components:
             <ul>
                 <li>
                     <ExternalBrowserLink text="CDT GDB Debug Adapter" url="https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter"
@@ -165,7 +165,7 @@ export function renderDownloads(): React.ReactNode {
             Updates and Downloads
         </h3>
         <div className='gs-action-container'>
-            You can update CDT.cloud Blueprint directly in this application by navigating to
+            You can update CDT Cloud Blueprint directly in this application by navigating to
             File {'>'} Settings {'>'} Check for Updates. Moreover the application will check for Updates
             after each launch automatically.
             Alternatively you can download the most recent version from our webpage.

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
@@ -104,7 +104,7 @@ export class TheiaBlueprintAboutDialog extends AboutDialog {
 
     protected renderTitle(): React.ReactNode {
         return <div className='gs-header'>
-            <h1>CDT.cloud <span className='gs-blue-header'>Blueprint</span></h1>
+            <h1>CDT Cloud <span className='gs-blue-header'>Blueprint</span></h1>
             {this.renderVersion()}
         </div>;
     }

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -142,7 +142,7 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
 
     protected renderHeader(): React.ReactNode {
         return <div className='gs-header'>
-            <h1>CDT.cloud <span className='gs-blue-header'>Blueprint</span></h1>
+            <h1>CDT Cloud <span className='gs-blue-header'>Blueprint</span></h1>
             {this.renderVersion()}
         </div>;
     }
@@ -218,7 +218,7 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenExternalLink('https://www.eclipse.org/cdt-cloud/documentation')}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, 'https://www.eclipse.org/cdt-cloud/documentation')}>
-                    {nls.localizeByDefault('CDT.cloud Documentation')}
+                    {nls.localizeByDefault('CDT Cloud Documentation')}
                 </a>
             </div>
             <div className='gs-action-container'>

--- a/theia-extensions/theia-blueprint-updater/package.json
+++ b/theia-extensions/theia-blueprint-updater/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "cdt-cloud-blueprint-updater",
   "version": "1.34.4",
-  "description": "CDT.cloud Blueprint Updater",
+  "description": "CDT Cloud Blueprint Updater",
   "dependencies": {
     "@theia/core": "1.34.4",
     "@theia/output": "1.34.4",


### PR DESCRIPTION
#### What it does
Renames `CDT.cloud` to `CDT Cloud` Blueprint.

Contributed on behalf of STMicroelectronics.

#### How to test
This change impacts only readmes, strings and package descriptions, so it really shouldn't have any impact on functionality.
