### PR TITLE
fix: CI compilation error in Windows build

### DIFF
--- a/applications/electron/scripts/update-blockmap.ts
+++ b/applications/electron/scripts/update-blockmap.ts
@@ -42,5 +42,5 @@ async function execute(): Promise<void> {
     fs.rmSync(blockMapFile, {
         force: true,
     });
-    const updateInfo = await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", executablePath, "--output", blockMapFile])
+    await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", executablePath, "--output", blockMapFile])
 }


### PR DESCRIPTION
#### What it does

Fixes the "Sign and Upload Windows" step in the Jenkins CI

Contributed on behalf of STMicroelectronics

#### Details

There is a typescript error during the "Sign and Upload Windows" step of the Jenkins CI, see https://ci.eclipse.org/theia/job/TheiaCDTCloud/job/master/26/

Comparing to Theia Blueprint we have additional tsconfig files and resolve to more Typescript versions. So this is where the difference might be coming from.

The `update-blockmap.ts` script is adapted to avoid the `error TS6133: 'updateInfo' is declared but its value is never read` error.

#### How to test
Merge and check whether the CI works
