### PR TITLE
Make sure to use authenticated Github calls during Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -251,9 +251,11 @@ spec:
                     steps {
                         unstash 'win'
                         container('theia-dev') {
-                            script {
-                                signInstaller('exe', 'windows')
-                                updateMetadata('CDTCloudBlueprint.exe', 'latest.yml', 'windows', 1200)
+                            withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
+                                script {
+                                    signInstaller('exe', 'windows')
+                                    updateMetadata('CDTCloudBlueprint.exe', 'latest.yml', 'windows', 1200)
+                                }
                             }
                         }
                         container('jnlp') {


### PR DESCRIPTION
#### What it does
Adds the `GITHUB_TOKEN` env variable in the jenkins build so that downloads from Github are performed authenticated. 
Rate limits for authenticated calls are higher. 

Contributed on behalf of STMicroelectronics

#### How to test
Can only be tested during the release build on Jenkins. 
Build should not run into rate limits any more. 
