### PR TITLE
fix: windows deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ spec:
                         container('jnlp') {
                             script {
                                 uploadInstaller('windows')
-                                copyInstallerAndUpdateLatestYml('windows', 'CDTCloudBlueprint', 'exe', 'latest.yml', '1.43.1')
+                                copyInstallerAndUpdateLatestYml('windows', 'CDTCloudBlueprint', 'exe', 'latest.yml', '1.40.1')
                             }
                         }
                     }


### PR DESCRIPTION
The Jenkinsfile expects the version number of the previous release(s) in the Windows script, not the current one. This version number is used to indicate which of the old Windows versions can be updated to the current one. This is now fixed, re-enabling the Windows update mechanism.

Contributed on behalf of STMicroelectronics

#### What it does
Instructs within the Jenkinsfile to update the `latest.yml` of the last stable Windows release 

#### How to test
Once merged, the Jenkins build should succeed, replacing the Windows `1.40.1` `latest.yml` with the new one
