### PR TITLE
build: adjust Jenkinsfile to new Windows naming

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,14 +254,14 @@ spec:
                             withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
                                 script {
                                     signInstaller('exe', 'windows')
-                                    updateMetadata('CDTCloudBlueprint.exe', 'latest.yml', 'windows', 1200)
+                                    updateMetadata('CDTCloudBlueprintSetup.exe', 'latest.yml', 'windows', 1200)
                                 }
                             }
                         }
                         container('jnlp') {
                             script {
                                 uploadInstaller('windows')
-                                copyInstallerAndUpdateLatestYml('windows', 'CDTCloudBlueprint', 'exe', 'latest.yml', '1.40.1')
+                                copyInstallerAndUpdateLatestYml('windows', 'CDTCloudBlueprintSetup', 'exe', 'latest.yml', '1.40.1')
                             }
                         }
                     }

--- a/applications/electron/scripts/update-blockmap.ts
+++ b/applications/electron/scripts/update-blockmap.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 const BLOCK_MAP_FILE_SUFFIX = '.blockmap';
 
 const argv = yargs(hideBin(process.argv))
-    .option('executable', { alias: 'e', type: 'string', default: 'CDTCloudBlueprint.exe', desription: 'The executable for which the blockmap needs to be updated' })
+    .option('executable', { alias: 'e', type: 'string', default: 'CDTCloudBlueprintSetup.exe', desription: 'The executable for which the blockmap needs to be updated' })
     .version(false)
     .wrap(120)
     .parseSync();

--- a/applications/electron/test/app.spec.js
+++ b/applications/electron/test/app.spec.js
@@ -18,7 +18,7 @@ function getBinaryPath() {
       return path.join(
         distFolder,
         'win-unpacked',
-        'CDTCloudBlueprint.exe'
+        'CDTCloudBlueprintSetup.exe'
       );
     case 'darwin':
       return path.join(


### PR DESCRIPTION
With the recent update, the installer is now called CDTCloudBlueprintSetup.exe. The Jenkinsfile is adapted to check for this naming.

Contributed on behalf of STMicroelectronics